### PR TITLE
Handle API change in `rq_for_each_segment`

### DIFF
--- a/srb_driver.c
+++ b/srb_driver.c
@@ -33,6 +33,7 @@
 #include <linux/blkdev.h>
 #include <linux/slab.h>
 #include <linux/kthread.h>
+#include <linux/version.h>
 
 #include "srb.h"
 
@@ -332,7 +333,11 @@ static int srb_thread(void *data)
 	int th_ret = 0;
 	char buff[256];
 	struct req_iterator iter;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 14, 0)
 	struct bio_vec *bvec;
+#else
+        struct bio_vec bvec;
+#endif
 	struct srb_cdmi_desc_s *cdmi_desc;
 
 	SRBDEV_LOG_DEBUG(((struct srb_device_s *)data), "Thread started with device %p", data);


### PR DESCRIPTION
The API of `rq_for_each_segment` changed, most likely in Linux 3.14 due
to commit 4550dd6c6b062fc5e5b647296d55da22616123c3.

This patch adds conditional compilation to work around this and support
both API versions.

Note: I tested compilation on my `3.17.3-200.fc20.x86_64` system, not on a 3.13 tree, please ensure this works before merging.
