### PR TITLE
Use `scnprintf` instead of `sprintf` + `strlen`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ obj-m := $(TARGET).o
 KDIR := /lib/modules/$(shell uname -r)/build
 PWD := $(shell pwd)
 
-ccflags-y += -g3 -Wunused -Wuninitialized -O2 -Wall -Werror -Warray-bounds -D_REENTRANT -DJSMN_PARENT_LINKS
+ccflags-y += -g3 -O2 -Wall -Wextra -Wno-unused-parameter -Werror -Warray-bounds -D_REENTRANT -DJSMN_PARENT_LINKS
 
 all:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules

--- a/srb_sysfs.c
+++ b/srb_sysfs.c
@@ -132,9 +132,7 @@ static ssize_t attr_debug_show(struct device *dv,
 	struct gendisk *disk	  = dev_to_disk(dv);
 	struct srb_device_s *dev = disk->private_data;
 	
-	snprintf(buff, PAGE_SIZE, "%d\n", dev->debug.level);
-
-	return strlen(buff);	
+	return scnprintf(buff, PAGE_SIZE, "%d\n", dev->debug.level);
 }
 
 
@@ -145,9 +143,7 @@ static ssize_t attr_urls_show(struct device *dv,
 	struct srb_device_s *dev = disk->private_data;
 	
 	//snprintf(buff, PAGE_SIZE, "%s\n", dev->thread_cdmi_desc[0].url);
-	snprintf(buff, PAGE_SIZE, "%s\n", dev->thread_cdmi_desc[0]->url);
-
-	return strlen(buff);
+	return scnprintf(buff, PAGE_SIZE, "%s\n", dev->thread_cdmi_desc[0]->url);
 }
 
 static ssize_t attr_disk_name_show(struct device *dv,
@@ -157,9 +153,7 @@ static ssize_t attr_disk_name_show(struct device *dv,
 	struct srb_device_s *dev = disk->private_data;
 
 	//snprintf(buff, PAGE_SIZE, "%s\n", kbasename(dev->thread_cdmi_desc[0].url));
-	snprintf(buff, PAGE_SIZE, "%s\n", kbasename(dev->thread_cdmi_desc[0]->url));
-
-	return strlen(buff);
+	return scnprintf(buff, PAGE_SIZE, "%s\n", kbasename(dev->thread_cdmi_desc[0]->url));
 }
 
 static ssize_t attr_disk_size_show(struct device *dv,
@@ -168,9 +162,7 @@ static ssize_t attr_disk_size_show(struct device *dv,
 	struct gendisk *disk	  = dev_to_disk(dv);
 	struct srb_device_s *dev = disk->private_data;
 	
-	snprintf(buff, PAGE_SIZE, "%llu\n", dev->disk_size);
-
-	return strlen(buff);
+	return scnprintf(buff, PAGE_SIZE, "%llu\n", dev->disk_size);
 }
 
 static DEVICE_ATTR(srb_debug, S_IWUSR | S_IRUGO, &attr_debug_show, &attr_debug_store);
@@ -203,9 +195,7 @@ static ssize_t class_srb_create_show(struct class *c, struct class_attribute *at
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo 'VolumeName size(bytes)' > create\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo 'VolumeName size(bytes)' > create\n");
 }
 
 static ssize_t class_srb_create_store(struct class *c,
@@ -289,11 +279,9 @@ static ssize_t class_srb_extend_show(struct class *c, struct class_attribute *at
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE,
+	return scnprintf(buf, PAGE_SIZE,
 		 "The new size must be greater than the current size.\n"
 		 "# Usage: echo 'VolumeName size(bytes)' > extend\n");
-
-	return strlen(buf);
 }
 
 static ssize_t class_srb_extend_store(struct class *c,
@@ -374,9 +362,7 @@ static ssize_t class_srb_destroy_show(struct class *c, struct class_attribute *a
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName > destroy\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName > destroy\n");
 }
 
 static ssize_t class_srb_destroy_store(struct class *c,
@@ -421,9 +407,7 @@ static ssize_t class_srb_attach_show(struct class *c, struct class_attribute *at
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName DeviceName > attach\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName DeviceName > attach\n");
 }
 
 static ssize_t class_srb_attach_store(struct class *c,
@@ -498,9 +482,7 @@ static ssize_t class_srb_detach_show(struct class *c, struct class_attribute *at
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo DeviceName > detach\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo DeviceName > detach\n");
 }
 
 static ssize_t class_srb_detach_store(struct class *c,
@@ -537,9 +519,7 @@ static ssize_t class_srb_addurl_show(struct class *c, struct class_attribute *at
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > add_urls\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > add_urls\n");
 }
 
 static ssize_t class_srb_addurl_store(struct class *c,
@@ -602,9 +582,7 @@ static ssize_t class_srb_removeurl_show(struct class *c, struct class_attribute 
 	(void)c;
 	(void)attr;
 
-	snprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > remove_urls\n");
-
-	return strlen(buf);
+	return scnprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > remove_urls\n");
 }
 
 static ssize_t class_srb_removeurl_store(struct class *c,

--- a/srb_sysfs.c
+++ b/srb_sysfs.c
@@ -192,9 +192,6 @@ static void class_srb_release(struct class *cls)
 static ssize_t class_srb_create_show(struct class *c, struct class_attribute *attr,
 				      char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo 'VolumeName size(bytes)' > create\n");
 }
 
@@ -209,8 +206,6 @@ static ssize_t class_srb_create_store(struct class *c,
 	char *params[2];
 	const char *delim = " ";
 	char *tmp_buf;
-	(void)c;
-	(void)attr;
 
 	SRB_LOG_INFO(srb_log, "Creating volume with params: %s (%lu)", buf, count);
 
@@ -276,9 +271,6 @@ out:
 static ssize_t class_srb_extend_show(struct class *c, struct class_attribute *attr,
 				      char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE,
 		 "The new size must be greater than the current size.\n"
 		 "# Usage: echo 'VolumeName size(bytes)' > extend\n");
@@ -297,8 +289,6 @@ static ssize_t class_srb_extend_store(struct class *c,
 	char *params[2];
 	const char *delim = " ";
 	char *tmp_buf;
-	(void)c;
-	(void)attr;
 
 	SRB_LOG_INFO(srb_log, "Extending volume with params: %s (%lu)", buf, count);
 
@@ -359,9 +349,6 @@ out:
 static ssize_t class_srb_destroy_show(struct class *c, struct class_attribute *attr,
 				       char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName > destroy\n");
 }
 
@@ -371,9 +358,6 @@ static ssize_t class_srb_destroy_store(struct class *c,
 {
 	ssize_t ret = 0;
 	char filename[SRB_URL_SIZE + 1];
-
-	(void)c;
-	(void)attr;
 
 	/* Sanity check URL size */
 	if ((count == 0) || (count >= SRB_URL_SIZE)) {
@@ -404,9 +388,6 @@ out:
 static ssize_t class_srb_attach_show(struct class *c, struct class_attribute *attr,
 				      char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo VolumeName DeviceName > attach\n");
 }
 
@@ -479,9 +460,6 @@ out:
 static ssize_t class_srb_detach_show(struct class *c, struct class_attribute *attr,
 				      char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo DeviceName > detach\n");
 }
 
@@ -516,9 +494,6 @@ static ssize_t class_srb_detach_store(struct class *c,
 static ssize_t class_srb_addurl_show(struct class *c, struct class_attribute *attr,
 					 char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > add_urls\n");
 }
 
@@ -579,9 +554,6 @@ end:
 static ssize_t class_srb_removeurl_show(struct class *c, struct class_attribute *attr,
 					    char *buf)
 {
-	(void)c;
-	(void)attr;
-
 	return scnprintf(buf, PAGE_SIZE, "# Usage: echo server_url1,...,server_urlN > remove_urls\n");
 }
 
@@ -645,9 +617,6 @@ static ssize_t class_srb_urls_show(struct class *c, struct class_attribute *attr
 {
 	ssize_t	ret = 0;
 
-	(void)c;
-	(void)attr;
-
 	ret = srb_servers_dump(buf, PAGE_SIZE);
 
 	return ret;
@@ -657,9 +626,6 @@ static ssize_t class_srb_volumes_show(struct class *c, struct class_attribute *a
 				       char *buf)
 {
 	ssize_t	ret = 0;
-
-	(void)c;
-	(void)attr;
 
 	ret = srb_volumes_dump(buf, PAGE_SIZE);
 


### PR DESCRIPTION
As mentioned in `Documentation/filesystems/sysfs.txt`:

```
- show() should always use scnprintf().
```