### PR TITLE
Fix for #99 Ghost data

### DIFF
--- a/srb_driver.c
+++ b/srb_driver.c
@@ -419,7 +419,11 @@ static int srb_thread(void *data)
 		                 th_id, th_ret);
 	
 		/* No IO error testing for the moment */
-		blk_end_request_all(req, 0);
+		if (th_ret < 0) {
+			blk_end_request_all(req, -EIO);
+		} else {
+			blk_end_request_all(req, 0);
+		}
 	}
 
 	return 0;

--- a/srb_driver.c
+++ b/srb_driver.c
@@ -418,7 +418,6 @@ static int srb_thread(void *data)
 		SRBDEV_LOG_DEBUG(dev, "thread %d: REQ done with returned code %d",
 		                 th_id, th_ret);
 	
-		/* No IO error testing for the moment */
 		if (th_ret < 0) {
 			blk_end_request_all(req, -EIO);
 		} else {


### PR DESCRIPTION
This is caused by the error return path not passing errors back to
the scatter gather block driver, instead always returning 0. This
changes this so that -EIO is returned if srb_xfer_scl() returns an
error.